### PR TITLE
Add snapshot frequency to Euler Forward driver

### DIFF
--- a/include/marco/Runtime/Printers/CSV/Options.h
+++ b/include/marco/Runtime/Printers/CSV/Options.h
@@ -7,6 +7,7 @@ namespace marco::runtime::printing
   {
     bool scientificNotation = false;
     unsigned int precision = 9;
+    bool disablePrinting = false;
   };
 
   PrintOptions& printOptions();

--- a/include/marco/Runtime/Simulation/Runtime.h
+++ b/include/marco/Runtime/Simulation/Runtime.h
@@ -34,6 +34,7 @@ namespace marco::runtime
 
       std::vector<int64_t> derOrders;
 
+
     private:
       Printer* printer;
   };

--- a/include/marco/Runtime/Solvers/EulerForward/Options.h
+++ b/include/marco/Runtime/Solvers/EulerForward/Options.h
@@ -8,6 +8,7 @@ namespace marco::runtime::eulerforward
   struct Options
   {
     double timeStep = 0.1;
+    std::size_t snapshotSteps = 1;
   };
 
   Options& getOptions();

--- a/lib/Drivers/EulerForward/CLI.cpp
+++ b/lib/Drivers/EulerForward/CLI.cpp
@@ -8,7 +8,8 @@ std::string CommandLineOptions::getTitle() const { return "Euler forward"; }
 
 void CommandLineOptions::printCommandLineOptions(std::ostream &os) const {
   // clang-format off
-  os << "  --time-step=<value>    Set the time step (in seconds). Defaults to " << getOptions().timeStep << "." << std::endl;
+  os << "  --time-step=<value>         Set the time step (in seconds). Defaults to " << getOptions().timeStep << "." << std::endl;
+  os << "  --snapshot-steps=<value>    Print simulation state every <value> time steps. Defaults to " << getOptions().snapshotSteps << "." << std::endl;
   // clang-format on
 }
 
@@ -16,6 +17,7 @@ void CommandLineOptions::parseCommandLineOptions(
     const argh::parser &options) const {
   // clang-format off
   options("time-step") >> getOptions().timeStep;
+  options("snapshot-steps") >> getOptions().snapshotSteps;
   // clang-format on
 }
 } // namespace marco::runtime::eulerforward

--- a/lib/Drivers/EulerForward/Driver.cpp
+++ b/lib/Drivers/EulerForward/Driver.cpp
@@ -26,6 +26,8 @@ int EulerForward::run() {
 
   do {
     iterationStep++;
+    bool snapshotCondition =
+        iterationStep % eulerforward::getOptions().snapshotSteps == 0;
 
     // Compute the next values of the state variables.
     if (marco::runtime::simulation::getOptions().debug) {
@@ -42,19 +44,21 @@ int EulerForward::run() {
                 << std::endl;
     }
 
-    EULER_FORWARD_PROFILER_NONSTATEVAR_START;
-    time = getTime() + eulerforward::getOptions().timeStep;
-    setTime(time);
+    if (snapshotCondition) {
+      EULER_FORWARD_PROFILER_NONSTATEVAR_START;
+      time = getTime() + eulerforward::getOptions().timeStep;
+      setTime(time);
 
-    updateNonStateVariables();
-    EULER_FORWARD_PROFILER_NONSTATEVAR_STOP;
+      updateNonStateVariables();
+      EULER_FORWARD_PROFILER_NONSTATEVAR_STOP;
+    }
 
     if (marco::runtime::simulation::getOptions().debug) {
       std::cerr << "[Euler Forward] Printing values" << std::endl;
     }
 
     // Print the values at a specified frequency.
-    if (iterationStep % eulerforward::getOptions().snapshotSteps == 0) {
+    if (snapshotCondition) {
       getSimulation()->getPrinter()->printValues();
     }
 

--- a/lib/Drivers/EulerForward/Driver.cpp
+++ b/lib/Drivers/EulerForward/Driver.cpp
@@ -1,77 +1,79 @@
 #include "marco/Runtime/Drivers/EulerForward/Driver.h"
 #include "marco/Runtime/Drivers/EulerForward/CLI.h"
-#include "marco/Runtime/Solvers/EulerForward/Options.h"
-#include "marco/Runtime/Solvers/EulerForward/Profiler.h"
 #include "marco/Runtime/Simulation/Options.h"
 #include "marco/Runtime/Simulation/Profiler.h"
 #include "marco/Runtime/Simulation/Runtime.h"
+#include "marco/Runtime/Solvers/EulerForward/Options.h"
+#include "marco/Runtime/Solvers/EulerForward/Profiler.h"
 #include <iostream>
 
-namespace marco::runtime
-{
-  EulerForward::EulerForward(Simulation* simulation)
-      : Driver(simulation)
-  {
-  }
+namespace marco::runtime {
+EulerForward::EulerForward(Simulation *simulation) : Driver(simulation) {}
 
 #ifdef CLI_ENABLE
-  std::unique_ptr<cli::Category> EulerForward::getCLIOptions()
-  {
-    return std::make_unique<eulerforward::CommandLineOptions>();
-  }
+std::unique_ptr<cli::Category> EulerForward::getCLIOptions() {
+  return std::make_unique<eulerforward::CommandLineOptions>();
+}
 #endif // CLI_ENABLE
 
-  int EulerForward::run()
-  {
+int EulerForward::run() {
+  if (marco::runtime::simulation::getOptions().debug) {
+    std::cerr << "[Euler Forward] Starting simulation" << std::endl;
+  }
+
+  double time;
+  std::size_t iterationStep = 0;
+
+  do {
+    iterationStep++;
+
+    // Compute the next values of the state variables.
     if (marco::runtime::simulation::getOptions().debug) {
-      std::cerr << "[Euler Forward] Starting simulation" << std::endl;
+      std::cerr << "[Euler Forward] Updating state variables" << std::endl;
     }
 
-    double time;
+    EULER_FORWARD_PROFILER_STATEVAR_START;
+    updateStateVariables(eulerforward::getOptions().timeStep);
+    EULER_FORWARD_PROFILER_STATEVAR_STOP;
 
-    do {
-      // Compute the next values of the state variables.
-      if (marco::runtime::simulation::getOptions().debug) {
-        std::cerr << "[Euler Forward] Updating state variables" << std::endl;
-      }
+    // Move to the next step.
+    if (marco::runtime::simulation::getOptions().debug) {
+      std::cerr << "[Euler Forward] Updating time and non-state variables"
+                << std::endl;
+    }
 
-      EULER_FORWARD_PROFILER_STATEVAR_START;
-      updateStateVariables(eulerforward::getOptions().timeStep);
-      EULER_FORWARD_PROFILER_STATEVAR_STOP;
+    EULER_FORWARD_PROFILER_NONSTATEVAR_START;
+    time = getTime() + eulerforward::getOptions().timeStep;
+    setTime(time);
 
-      // Move to the next step.
-      if (marco::runtime::simulation::getOptions().debug) {
-        std::cerr << "[Euler Forward] Updating time and non-state variables" << std::endl;
-      }
+    updateNonStateVariables();
+    EULER_FORWARD_PROFILER_NONSTATEVAR_STOP;
 
-      EULER_FORWARD_PROFILER_NONSTATEVAR_START;
-      time = getTime() + eulerforward::getOptions().timeStep;
-      setTime(time);
+    if (marco::runtime::simulation::getOptions().debug) {
+      std::cerr << "[Euler Forward] Printing values" << std::endl;
+    }
 
-      updateNonStateVariables();
-      EULER_FORWARD_PROFILER_NONSTATEVAR_STOP;
-
-      if (marco::runtime::simulation::getOptions().debug) {
-        std::cerr << "[Euler Forward] Printing values" << std::endl;
-      }
-
-      // Print the values.
+    // Print the values at a specified frequency.
+    if (iterationStep % eulerforward::getOptions().snapshotSteps == 0) {
       getSimulation()->getPrinter()->printValues();
-    } while (std::abs(simulation::getOptions().endTime - time) >=
-             eulerforward::getOptions().timeStep);
-
-    if (marco::runtime::simulation::getOptions().debug) {
-      std::cerr << "[Euler Forward] Simulation finished" << std::endl;
     }
 
-    return EXIT_SUCCESS;
-  }
-}
+  } while (std::abs(simulation::getOptions().endTime - time) >=
+           eulerforward::getOptions().timeStep);
 
-namespace marco::runtime
-{
-  std::unique_ptr<Driver> getDriver(Simulation* simulation)
-  {
-    return std::make_unique<EulerForward>(simulation);
+  iterationStep++;
+  getSimulation()->getPrinter()->printValues();
+
+  if (marco::runtime::simulation::getOptions().debug) {
+    std::cerr << "[Euler Forward] Simulation finished" << std::endl;
   }
+
+  return EXIT_SUCCESS;
 }
+} // namespace marco::runtime
+
+namespace marco::runtime {
+std::unique_ptr<Driver> getDriver(Simulation *simulation) {
+  return std::make_unique<EulerForward>(simulation);
+}
+} // namespace marco::runtime

--- a/lib/Printers/CSV/CLI.cpp
+++ b/lib/Printers/CSV/CLI.cpp
@@ -8,16 +8,18 @@ std::string CommandLineOptions::getTitle() const { return "Formatting"; }
 
 void CommandLineOptions::printCommandLineOptions(std::ostream &os) const {
   // clang-format off
-  os << "  --scientific-notation    Print the values using the scientific notation." << std::endl;
-  os << "  --precision=<value>      Set the number of decimals to be printed. Defaults to " << printOptions().precision << "." << std::endl;
+  os << "  --scientific-notation             Print the values using the scientific notation." << std::endl;
+  os << "  --precision=<value>               Set the number of decimals to be printed. Defaults to " << printOptions().precision << "." << std::endl;
+  os << "  --disable-printing                Disables output. Useful for testing performance without I/O overhead. Defaults to " << printOptions().disablePrinting << "." << std::endl;
   // clang-format on
 }
 
 void CommandLineOptions::parseCommandLineOptions(
     const argh::parser &options) const {
   // clang-format off
-  printOptions().scientificNotation = options["scientific-notation"];
-  options("precision") >> printOptions().precision;
+    printOptions().scientificNotation = options["scientific-notation"];
+    options("precision") >> printOptions().precision;
+    printOptions().disablePrinting = options["disable-printing"];
   // clang-format on
 }
 } // namespace marco::runtime::printing

--- a/lib/Printers/CSV/Printer.cpp
+++ b/lib/Printers/CSV/Printer.cpp
@@ -11,8 +11,7 @@
 using namespace ::marco::runtime;
 using namespace ::marco::runtime::printing;
 
-static void printDerWrapOpening(int64_t order)
-{
+static void printDerWrapOpening(int64_t order) {
   for (int64_t i = 0; i < order; ++i) {
     PRINT_PROFILER_STRING_START;
     std::cout << "der(";
@@ -20,8 +19,7 @@ static void printDerWrapOpening(int64_t order)
   }
 }
 
-static void printDerWrapClosing(int64_t order)
-{
+static void printDerWrapClosing(int64_t order) {
   for (int64_t i = 0; i < order; ++i) {
     PRINT_PROFILER_STRING_START;
     std::cout << ')';
@@ -29,8 +27,7 @@ static void printDerWrapClosing(int64_t order)
   }
 }
 
-static void printName(char* name, int64_t rank, const int64_t* indices)
-{
+static void printName(char *name, int64_t rank, const int64_t *indices) {
   PRINT_PROFILER_STRING_START;
   std::cout << name;
   PRINT_PROFILER_STRING_STOP;
@@ -58,8 +55,12 @@ static void printName(char* name, int64_t rank, const int64_t* indices)
   }
 }
 
-static void printHeader(const Simulation& simulation)
-{
+static void printHeader(const Simulation &simulation) {
+
+  if (printOptions().disablePrinting) {
+    return;
+  }
+
   PRINT_PROFILER_STRING_START;
   std::cout << '"' << "time" << '"';
   PRINT_PROFILER_STRING_STOP;
@@ -85,7 +86,7 @@ static void printHeader(const Simulation& simulation)
     }
 
     assert(baseVar != -1);
-    char* name = simulation.variablesNames[baseVar];
+    char *name = simulation.variablesNames[baseVar];
 
     if (rank == 0) {
       // Print only the variable name.
@@ -104,7 +105,7 @@ static void printHeader(const Simulation& simulation)
       // Print the name of the array and the indices, for each possible
       // combination of printable indices.
 
-      for (const auto& range : simulation.variablesPrintableIndices[var]) {
+      for (const auto &range : simulation.variablesPrintableIndices[var]) {
         auto beginIt = MultidimensionalRangeIterator::begin(range);
         auto endIt = MultidimensionalRangeIterator::end(range);
 
@@ -130,9 +131,13 @@ static void printHeader(const Simulation& simulation)
   PRINT_PROFILER_STRING_STOP;
 }
 
-static void printValues(const Simulation& simulation)
-{
-  auto& options = printOptions();
+static void printValues(const Simulation &simulation) {
+  auto &options = printOptions();
+
+  if (options.disablePrinting) {
+    return;
+  }
+
   std::cout.precision(options.precision);
 
   if (options.scientificNotation) {
@@ -173,7 +178,7 @@ static void printValues(const Simulation& simulation)
       PRINT_PROFILER_FLOAT_STOP;
     } else {
       // Print the components of the array variable.
-      for (const auto& range : simulation.variablesPrintableIndices[var]) {
+      for (const auto &range : simulation.variablesPrintableIndices[var]) {
         auto beginIt = MultidimensionalRangeIterator::begin(range);
         auto endIt = MultidimensionalRangeIterator::end(range);
 
@@ -197,44 +202,34 @@ static void printValues(const Simulation& simulation)
   PRINT_PROFILER_STRING_STOP;
 }
 
-namespace marco::runtime::printing
-{
-  CSVPrinter::CSVPrinter(Simulation* simulation)
-      : Printer(simulation)
-  {
-  }
+namespace marco::runtime::printing {
+CSVPrinter::CSVPrinter(Simulation *simulation) : Printer(simulation) {}
 
 #ifdef CLI_ENABLE
-  std::unique_ptr<cli::Category> CSVPrinter::getCLIOptions()
-  {
-    return std::make_unique<CommandLineOptions>();
-  }
+std::unique_ptr<cli::Category> CSVPrinter::getCLIOptions() {
+  return std::make_unique<CommandLineOptions>();
+}
 #endif // CLI_ENABLE
 
-  void CSVPrinter::simulationBegin()
-  {
-    SIMULATION_PROFILER_PRINTING_START;
-    ::printHeader(*getSimulation());
-    SIMULATION_PROFILER_PRINTING_STOP;
-  }
-
-  void CSVPrinter::printValues()
-  {
-    SIMULATION_PROFILER_PRINTING_START;
-    ::printValues(*getSimulation());
-    SIMULATION_PROFILER_PRINTING_STOP;
-  }
-
-  void CSVPrinter::simulationEnd()
-  {
-    // Do nothing.
-  }
+void CSVPrinter::simulationBegin() {
+  SIMULATION_PROFILER_PRINTING_START;
+  ::printHeader(*getSimulation());
+  SIMULATION_PROFILER_PRINTING_STOP;
 }
 
-namespace marco::runtime
-{
-  std::unique_ptr<Printer> getPrinter(Simulation* simulation)
-  {
-    return std::make_unique<printing::CSVPrinter>(simulation);
-  }
+void CSVPrinter::printValues() {
+  SIMULATION_PROFILER_PRINTING_START;
+  ::printValues(*getSimulation());
+  SIMULATION_PROFILER_PRINTING_STOP;
 }
+
+void CSVPrinter::simulationEnd() {
+  // Do nothing.
+}
+} // namespace marco::runtime::printing
+
+namespace marco::runtime {
+std::unique_ptr<Printer> getPrinter(Simulation *simulation) {
+  return std::make_unique<printing::CSVPrinter>(simulation);
+}
+} // namespace marco::runtime

--- a/lib/Simulation/Runtime.cpp
+++ b/lib/Simulation/Runtime.cpp
@@ -1,12 +1,12 @@
 #include "marco/Runtime/Simulation/Runtime.h"
 #include "marco/Runtime/CLI/CLI.h"
+#include "marco/Runtime/Drivers/Driver.h"
 #include "marco/Runtime/Multithreading/CLI.h"
+#include "marco/Runtime/Printers/Printer.h"
 #include "marco/Runtime/Profiling/Profiling.h"
 #include "marco/Runtime/Simulation/CLI.h"
 #include "marco/Runtime/Simulation/Options.h"
 #include "marco/Runtime/Simulation/Profiler.h"
-#include "marco/Runtime/Drivers/Driver.h"
-#include "marco/Runtime/Printers/Printer.h"
 #include <cassert>
 #include <iostream>
 
@@ -16,21 +16,19 @@ using namespace ::marco::runtime;
 // Functions defined inside the module of the compiled model
 //===---------------------------------------------------------------------===//
 
-extern "C"
-{
-  /// Initialize the simulation.
-  void init();
+extern "C" {
+/// Initialize the simulation.
+void init();
 
-  /// Deinitialize the simulation.
-  void deinit();
+/// Deinitialize the simulation.
+void deinit();
 }
 
 //===---------------------------------------------------------------------===//
 // CLI
 //===---------------------------------------------------------------------===//
 
-static void printHelp()
-{
+static void printHelp() {
   std::cout << "Modelica simulation.\n";
   std::cout << "Model: " << getModelName() << "\n";
   std::cout << "Generated with MARCO compiler.\n\n";
@@ -39,7 +37,7 @@ static void printHelp()
   std::cout << "OPTIONS:\n";
   std::cout << "  --help    Display the available options.\n\n";
 
-  auto& cli = getCLI();
+  auto &cli = getCLI();
 
   for (size_t i = 0; i < cli.size(); ++i) {
     std::cout << cli[i].getTitle() << "\n";
@@ -53,160 +51,152 @@ static void printHelp()
 // Simulation
 //===---------------------------------------------------------------------===//
 
-namespace marco::runtime
-{
-  Printer* Simulation::getPrinter()
-  {
-    assert(printer != nullptr);
-    return printer;
-  }
-
-  const Printer* Simulation::getPrinter() const
-  {
-    assert(printer != nullptr);
-    return printer;
-  }
-
-  void Simulation::setPrinter(Printer* newPrinter)
-  {
-    assert(newPrinter != nullptr);
-    printer = newPrinter;
-  }
+namespace marco::runtime {
+Printer *Simulation::getPrinter() {
+  assert(printer != nullptr);
+  return printer;
 }
 
-namespace
-{
-  Simulation runtimeInit()
-  {
-    #ifdef MARCO_PROFILING
-    profilingInit();
-    #endif
-
-    Simulation result;
-
-    // Number of array variables of the model (both state and algebraic ones).
-    int64_t numOfVariables = getNumOfVariables();
-
-    // Pre-fetch the names.
-    result.variablesNames.resize(numOfVariables);
-
-    for (int64_t var = 0; var < numOfVariables; ++var) {
-      result.variablesNames[var] = getVariableName(var);
-    }
-
-    // Pre-fetch the ranks.
-    result.variablesRanks.resize(numOfVariables);
-
-    for (int64_t var = 0; var < numOfVariables; ++var) {
-      result.variablesRanks[var] = getVariableRank(var);
-    }
-
-    // Pre-fetch whether each variable is printable.
-    result.printableVariables.resize(numOfVariables);
-
-    for (int64_t var = 0; var < numOfVariables; ++var) {
-      result.printableVariables[var] = isPrintable(var);
-    }
-
-    // Pre-fetch the printable indices.
-    result.variablesPrintableIndices.resize(numOfVariables);
-    result.variablesPrintOrder.resize(numOfVariables);
-
-    for (int64_t var = 0; var < numOfVariables; ++var) {
-      int64_t numOfPrintableRanges = getVariableNumOfPrintableRanges(var);
-      result.variablesPrintableIndices[var].resize(numOfPrintableRanges);
-
-      for (int64_t range = 0; range < numOfPrintableRanges; ++range) {
-        int64_t rank = result.variablesRanks[var];
-        result.variablesPrintableIndices[var][range].resize(rank);
-
-        for (int64_t dim = 0; dim < rank; ++dim) {
-          result.variablesPrintableIndices[var][range][dim].begin =
-              getVariablePrintableRangeBegin(var, range, dim);
-
-          result.variablesPrintableIndices[var][range][dim].end =
-              getVariablePrintableRangeEnd(var, range, dim);
-        }
-      }
-
-      result.variablesPrintOrder[var] = var;
-    }
-
-    // Pre-fetch the derivatives map.
-    result.derivativesMap.resize(numOfVariables);
-
-    for (int64_t var = 0; var < numOfVariables; ++var) {
-      result.derivativesMap[var] = -1;
-    }
-
-    for (int64_t var = 0; var < numOfVariables; ++var) {
-      int64_t derivative = getDerivative(var);
-
-      if (derivative != -1) {
-        result.derivativesMap[derivative] = var;
-      }
-    }
-
-    // Compute the derivative order of each variable.
-    result.derOrders.resize(numOfVariables);
-
-    for (int64_t var = 0; var < numOfVariables; ++var) {
-      int64_t currentVar = result.derivativesMap[var];
-      int64_t order = 0;
-
-      while (currentVar != -1) {
-        ++order;
-        currentVar = result.derivativesMap[currentVar];
-      }
-
-      result.derOrders[var] = order;
-    }
-
-    // Determine the print ordering for the variables.
-    std::sort(result.variablesPrintOrder.begin(),
-              result.variablesPrintOrder.end(),
-              [&](const int64_t& x, const int64_t& y) -> bool {
-                int64_t xDerOrder = result.derOrders[x];
-                int64_t yDerOrder = result.derOrders[y];
-
-                if (xDerOrder < yDerOrder) {
-                  return true;
-                }
-
-                if (xDerOrder > yDerOrder) {
-                  return false;
-                }
-
-                int64_t first = x;
-                int64_t second = y;
-
-                if (xDerOrder != 0) {
-                  for (int64_t i = 0; i < xDerOrder; ++i) {
-                    first = result.derivativesMap[first];
-                  }
-
-                  for (int64_t i = 0; i < yDerOrder; ++i) {
-                    second = result.derivativesMap[second];
-                  }
-                }
-
-                return std::string_view(result.variablesNames[first]) <
-                    std::string_view(result.variablesNames[second]);
-              });
-
-    return result;
-  }
-
-  void runtimeDeinit(Simulation& simulationInfo)
-  {
-    #ifdef MARCO_PROFILING
-    printProfilingStats();
-    #endif
-  }
+const Printer *Simulation::getPrinter() const {
+  assert(printer != nullptr);
+  return printer;
 }
 
-[[maybe_unused]] int runSimulation(int argc, char* argv[])
-{
+void Simulation::setPrinter(Printer *newPrinter) {
+  assert(newPrinter != nullptr);
+  printer = newPrinter;
+}
+} // namespace marco::runtime
+
+namespace {
+Simulation runtimeInit() {
+#ifdef MARCO_PROFILING
+  profilingInit();
+#endif
+
+  Simulation result;
+
+  // Number of array variables of the model (both state and algebraic ones).
+  int64_t numOfVariables = getNumOfVariables();
+
+  // Pre-fetch the names.
+  result.variablesNames.resize(numOfVariables);
+
+  for (int64_t var = 0; var < numOfVariables; ++var) {
+    result.variablesNames[var] = getVariableName(var);
+  }
+
+  // Pre-fetch the ranks.
+  result.variablesRanks.resize(numOfVariables);
+
+  for (int64_t var = 0; var < numOfVariables; ++var) {
+    result.variablesRanks[var] = getVariableRank(var);
+  }
+
+  // Pre-fetch whether each variable is printable.
+  result.printableVariables.resize(numOfVariables);
+
+  for (int64_t var = 0; var < numOfVariables; ++var) {
+    result.printableVariables[var] = isPrintable(var);
+  }
+
+  // Pre-fetch the printable indices.
+  result.variablesPrintableIndices.resize(numOfVariables);
+  result.variablesPrintOrder.resize(numOfVariables);
+
+  for (int64_t var = 0; var < numOfVariables; ++var) {
+    int64_t numOfPrintableRanges = getVariableNumOfPrintableRanges(var);
+    result.variablesPrintableIndices[var].resize(numOfPrintableRanges);
+
+    for (int64_t range = 0; range < numOfPrintableRanges; ++range) {
+      int64_t rank = result.variablesRanks[var];
+      result.variablesPrintableIndices[var][range].resize(rank);
+
+      for (int64_t dim = 0; dim < rank; ++dim) {
+        result.variablesPrintableIndices[var][range][dim].begin =
+            getVariablePrintableRangeBegin(var, range, dim);
+
+        result.variablesPrintableIndices[var][range][dim].end =
+            getVariablePrintableRangeEnd(var, range, dim);
+      }
+    }
+
+    result.variablesPrintOrder[var] = var;
+  }
+
+  // Pre-fetch the derivatives map.
+  result.derivativesMap.resize(numOfVariables);
+
+  for (int64_t var = 0; var < numOfVariables; ++var) {
+    result.derivativesMap[var] = -1;
+  }
+
+  for (int64_t var = 0; var < numOfVariables; ++var) {
+    int64_t derivative = getDerivative(var);
+
+    if (derivative != -1) {
+      result.derivativesMap[derivative] = var;
+    }
+  }
+
+  // Compute the derivative order of each variable.
+  result.derOrders.resize(numOfVariables);
+
+  for (int64_t var = 0; var < numOfVariables; ++var) {
+    int64_t currentVar = result.derivativesMap[var];
+    int64_t order = 0;
+
+    while (currentVar != -1) {
+      ++order;
+      currentVar = result.derivativesMap[currentVar];
+    }
+
+    result.derOrders[var] = order;
+  }
+
+  // Determine the print ordering for the variables.
+  std::sort(result.variablesPrintOrder.begin(),
+            result.variablesPrintOrder.end(),
+            [&](const int64_t &x, const int64_t &y) -> bool {
+              int64_t xDerOrder = result.derOrders[x];
+              int64_t yDerOrder = result.derOrders[y];
+
+              if (xDerOrder < yDerOrder) {
+                return true;
+              }
+
+              if (xDerOrder > yDerOrder) {
+                return false;
+              }
+
+              int64_t first = x;
+              int64_t second = y;
+
+              if (xDerOrder != 0) {
+                for (int64_t i = 0; i < xDerOrder; ++i) {
+                  first = result.derivativesMap[first];
+                }
+
+                for (int64_t i = 0; i < yDerOrder; ++i) {
+                  second = result.derivativesMap[second];
+                }
+              }
+
+              return std::string_view(result.variablesNames[first]) <
+                     std::string_view(result.variablesNames[second]);
+            });
+
+  return result;
+}
+
+void runtimeDeinit(Simulation &simulationInfo) {
+#ifdef MARCO_PROFILING
+  printProfilingStats();
+#endif
+}
+} // namespace
+
+[[maybe_unused]] int runSimulation(int argc, char *argv[]) {
   // Initialize the runtime library.
   Simulation simulation = runtimeInit();
 
@@ -220,7 +210,7 @@ namespace
   // Parse the command-line arguments.
 #ifdef CLI_ENABLE
   SIMULATION_PROFILER_ARG_START;
-  auto& cli = getCLI();
+  auto &cli = getCLI();
   cli += simulation::getCLIOptions();
 
 #ifdef THREADS_ENABLE
@@ -269,7 +259,6 @@ namespace
   int result = driver->run();
   dynamicModelEnd();
   SIMULATION_PROFILER_DYNAMIC_MODEL_STOP;
-
 
   // Tell the printer that the simulation has finished.
   simulation.getPrinter()->simulationEnd();

--- a/lib/Simulation/Runtime.cpp
+++ b/lib/Simulation/Runtime.cpp
@@ -270,6 +270,7 @@ namespace
   dynamicModelEnd();
   SIMULATION_PROFILER_DYNAMIC_MODEL_STOP;
 
+
   // Tell the printer that the simulation has finished.
   simulation.getPrinter()->simulationEnd();
 


### PR DESCRIPTION
This PR adds a snapshot frequency CLI parameter for the formatter.

Setting a positive value greater than 1 will cause the printer to skip iteration numbers that are not divisible by the snapshot frequency.