### PR TITLE
Add support for assertions

### DIFF
--- a/include/marco/Runtime/Support/BuiltInFunctions.h
+++ b/include/marco/Runtime/Support/BuiltInFunctions.h
@@ -17,6 +17,8 @@ RUNTIME_FUNC_DECL(acos, double, double)
 RUNTIME_FUNC_DECL(asin, float, float)
 RUNTIME_FUNC_DECL(asin, double, double)
 
+RUNTIME_FUNC_DECL(assert, void, bool, PTR(void), uint64_t)
+
 RUNTIME_FUNC_DECL(atan, float, float)
 RUNTIME_FUNC_DECL(atan, double, double)
 

--- a/lib/Support/BuiltInFunctions.cpp
+++ b/lib/Support/BuiltInFunctions.cpp
@@ -1,7 +1,9 @@
 #include "marco/Runtime/Support/BuiltInFunctions.h"
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <numeric>
+#include <string>
 #include <vector>
 
 //===----------------------------------------------------------------------===//
@@ -51,6 +53,28 @@ double asin_f64(double value) { return std::asin(value); }
 
 RUNTIME_FUNC_DEF(asin, float, float)
 RUNTIME_FUNC_DEF(asin, double, double)
+
+//===----------------------------------------------------------------------===//
+// assert
+//===----------------------------------------------------------------------===//
+
+namespace {
+void assert_void(bool condition, void *message, uint64_t level) {
+  assert((level == 0 || level == 1) && "Unexpected assert level");
+
+  if (!condition) {
+    if (level == 0) {
+      std::cerr << "warning: " << static_cast<const char *>(message)
+                << std::endl;
+    } else {
+      std::cerr << "error: " << static_cast<const char *>(message) << std::endl;
+      std::abort();
+    }
+  }
+}
+} // namespace
+
+RUNTIME_FUNC_DEF(assert, void, bool, PTR(void), uint64_t)
 
 //===----------------------------------------------------------------------===//
 // atan

--- a/unittest/BuiltInFunctionsTest.cpp
+++ b/unittest/BuiltInFunctionsTest.cpp
@@ -3275,3 +3275,38 @@ TEST(Runtime, zeros_f64) {
   EXPECT_DOUBLE_EQ(array[1][0], 0);
   EXPECT_DOUBLE_EQ(array[1][1], 0);
 }
+
+TEST(Runtime, assert_void) {
+  auto assertFn = [](bool cond, char *msg, int64_t assertionLevel) -> void {
+    return NAME_MANGLED(assert, void, bool, PTR(void), int64_t)(cond, msg,
+                                                                assertionLevel);
+  };
+
+  std::string s("Test");
+
+  EXPECT_EXIT(
+      {
+        assertFn(true, s.data(), 0);
+        std::cerr << "success" << std::endl;
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "success");
+
+  EXPECT_EXIT(
+      {
+        assertFn(true, s.data(), 1);
+        std::cerr << "success" << std::endl;
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "success");
+
+  EXPECT_EXIT(
+      {
+        assertFn(false, s.data(), 0);
+        std::exit(0);
+      },
+      testing::ExitedWithCode(0), "warning: " + s);
+
+  EXPECT_EXIT(assertFn(false, s.data(), 1), testing::KilledBySignal(SIGABRT),
+              "error: " + s);
+}


### PR DESCRIPTION
This PR adds support for assertions in MARCO runtime library.

MARCO will soon be able to lower Modelica assert() operations as well as introducing assertions along the pipeline for runtime verification purposes, so there is need for an assert() function here.
Since the C++ built-in `assert` macro is quite limited (only C++26 will add support for user-generated error messages), we reimplemented its logic following glibc implementation.