### PR TITLE
Set default simulation parameters.

### DIFF
--- a/include/marco/Runtime/Simulation/Runtime.h
+++ b/include/marco/Runtime/Simulation/Runtime.h
@@ -68,6 +68,23 @@ extern "C" {
 //===---------------------------------------------------------------------===//
 
 extern "C" {
+
+/// Returns true if the model beeing simulated has a specified default start
+/// time.
+bool hasExperimentStartTime();
+
+/// Returns true if the model beeing simulated has a specified default end time.
+bool hasExperimentEndTime();
+
+/// Gets the specified default start time of the simulation.
+/// `bool hasExperimentStartTime()` must be checked before calling this
+/// function.
+double getExperimentStartTime();
+
+/// Gets the specified default end time of the simulation.
+/// `bool hasExperimentEndTime()` must be checked before calling this function.
+double getExperimentEndTime();
+
 /// Get the current time of the simulation.
 double getTime();
 

--- a/lib/Simulation/Runtime.cpp
+++ b/lib/Simulation/Runtime.cpp
@@ -267,6 +267,16 @@ void runtimeDeinit(Simulation &simulationInfo) {
 
   cli += printer->getCLIOptions();
 
+  // The default start and end time must be set before the CLI runs in order to
+  // get the correct defaults in the help text.
+  if (hasExperimentStartTime()) {
+    simulation::getOptions().startTime = getExperimentStartTime();
+  }
+
+  if (hasExperimentEndTime()) {
+    simulation::getOptions().endTime = getExperimentEndTime();
+  }
+
   argh::parser cmdl(argc, argv);
 
   if (cmdl["help"]) {


### PR DESCRIPTION
This is the runtime part of the changes made in https://github.com/marco-compiler/marco/pull/156.