### PR TITLE
Update version of SUNDIALS and related packages

### DIFF
--- a/dependencies/sundials.sh
+++ b/dependencies/sundials.sh
@@ -35,18 +35,17 @@ cd "$TEMP_DIR" || fail "Error creating the temporary directory"
 
 BUILD_TYPE=Release
 
-OPENBLAS=OpenBLAS-0.3.23
-SUITESPARSE=SuiteSparse-7.1.0
-SUNDIALS=sundials-6.6.0
+OPENBLAS=OpenBLAS-0.3.31
+SUITESPARSE=SuiteSparse-7.12.2
+SUNDIALS=sundials-7.6.0
 
-OPENBLAS_URL=https://github.com/xianyi/OpenBLAS/releases/download/v0.3.23/OpenBLAS-0.3.23.tar.gz
-SUITESPARSE_URL=https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v7.1.0.tar.gz
-SUNDIALS_URL=https://github.com/LLNL/sundials/releases/download/v6.6.0/sundials-6.6.0.tar.gz
+OPENBLAS_URL=https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.31/OpenBLAS-0.3.31.tar.gz
+SUITESPARSE_URL=https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.12.2.tar.gz
+SUNDIALS_URL=https://github.com/llnl/sundials/archive/refs/tags/v7.6.0.tar.gz
 
-[ -f $OPENBLAS.tar.gz ]    || wget $OPENBLAS_URL    || fail "Error downloading $OPENBLAS.tar.gz"
-[ -f $SUITESPARSE.tar.gz ] || wget $SUITESPARSE_URL || fail "Error downloading $SUITESPARSE.tar.gz"
-[ -f $SUITESPARSE.tar.gz ] || mv v7.1.0.tar.gz $SUITESPARSE.tar.gz # HACK to fix file name
-[ -f $SUNDIALS.tar.gz ]    || wget $SUNDIALS_URL    || fail "Error downloading $SUNDIALS.tar.gz"
+[ -f $OPENBLAS.tar.gz ]    || wget $OPENBLAS_URL -O $OPENBLAS.tar.gz        || fail "Error downloading $OPENBLAS.tar.gz"
+[ -f $SUITESPARSE.tar.gz ] || wget $SUITESPARSE_URL -O $SUITESPARSE.tar.gz  || fail "Error downloading $SUITESPARSE.tar.gz"
+[ -f $SUNDIALS.tar.gz ]    || wget $SUNDIALS_URL -O $SUNDIALS.tar.gz        || fail "Error downloading $SUNDIALS.tar.gz"
 
 tar xzvf $OPENBLAS.tar.gz    || fail "Error extracting $OPENBLAS.tar.gz"
 tar xzvf $SUITESPARSE.tar.gz || fail "Error extracting $SUITESPARSE.tar.gz"
@@ -117,7 +116,7 @@ cd $SUNDIALS|| fail "Error extracting $SUNDIALS.tar.gz"
 # ENABLE_XBRAID                    OFF
 mkdir build
 cd build || fail "Error creating the build folder for Sundials"
-cmake .. -DENABLE_KLU=ON -DKLU_INCLUDE_DIR="$INSTDIR/include" -DKLU_LIBRARY_DIR="$INSTDIR/lib" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX="$INSTDIR" -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON
+cmake .. -DENABLE_KLU=ON -DKLU_INCLUDE_DIR="$INSTDIR/include/suitesparse" -DKLU_LIBRARY_DIR="$INSTDIR/lib" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX="$INSTDIR" -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON
 make -j `nproc` || fail "Sundials build failed"
 make install || fail "Sundials install failed"
 

--- a/include/marco/Runtime/Solvers/IDA/Instance.h
+++ b/include/marco/Runtime/Solvers/IDA/Instance.h
@@ -204,7 +204,6 @@ private:
   bool idaSetInitialStepSize();
   bool idaSetMinStepSize();
   bool idaSetMaxStepSize();
-  bool idaSetStopTime();
   bool idaSetMaxErrTestFails();
   bool idaSetSuppressAlg();
   bool idaSetId();
@@ -281,6 +280,7 @@ private:
   std::vector<uint64_t> equationOffsets;
 
   // Simulation times.
+  int64_t stepsNumber{0};
   realtype startTime;
   realtype endTime;
   realtype timeStep;

--- a/include/marco/Runtime/Solvers/IDA/Instance.h
+++ b/include/marco/Runtime/Solvers/IDA/Instance.h
@@ -232,6 +232,10 @@ private:
   /// }
 
 private:
+#if SUNDIALS_VERSION_MAJOR >= 7
+  SUNComm comm{0};
+#endif
+
 #if SUNDIALS_VERSION_MAJOR >= 6
   // SUNDIALS context.
   SUNContext ctx{nullptr};

--- a/include/marco/Runtime/Solvers/KINSOL/Instance.h
+++ b/include/marco/Runtime/Solvers/KINSOL/Instance.h
@@ -173,6 +173,10 @@ private:
   /// }
 
 private:
+#if SUNDIALS_VERSION_MAJOR >= 7
+  SUNComm comm{0};
+#endif
+
 #if SUNDIALS_VERSION_MAJOR >= 6
   // SUNDIALS context.
   SUNContext ctx{nullptr};

--- a/lib/Solvers/IDA/Instance.cpp
+++ b/lib/Solvers/IDA/Instance.cpp
@@ -648,7 +648,7 @@ bool IDAInstance::initialize() {
   }
 
   if (!idaSetUserData() || !idaSetMaxNumSteps() || !idaSetInitialStepSize() ||
-      !idaSetMinStepSize() || !idaSetMaxStepSize() || !idaSetStopTime() ||
+      !idaSetMinStepSize() || !idaSetMaxStepSize() ||
       !idaSetMaxErrTestFails() || !idaSetSuppressAlg() || !idaSetId() ||
       !idaSetJacobianFunction() || !idaSetMaxNonlinIters() ||
       !idaSetMaxConvFails() || !idaSetNonlinConvCoef() ||
@@ -787,12 +787,13 @@ bool IDAInstance::step() {
   IDA_PROFILER_STEPS_COUNTER_INCREMENT
   IDA_PROFILER_STEP_START
 
-  realtype tout =
-      getOptions().equidistantTimeGrid ? (currentTime + timeStep) : endTime;
+  ++stepsNumber;
 
-  auto solveRetVal = IDASolve(
-      idaMemory, tout, &currentTime, variablesVector, derivativesVector,
-      getOptions().equidistantTimeGrid ? IDA_NORMAL : IDA_ONE_STEP);
+  realtype tout =
+      getOptions().equidistantTimeGrid ? (stepsNumber * timeStep) : endTime;
+
+  auto solveRetVal = IDASolve(idaMemory, tout, &currentTime, variablesVector,
+                              derivativesVector, IDA_NORMAL);
 
   IDA_PROFILER_STEP_STOP
 
@@ -1683,24 +1684,6 @@ bool IDAInstance::idaSetMaxStepSize() {
   if (retVal == IDA_ILL_INPUT) {
     std::cerr << "IDASetMaxStep - Either hmax is not positive or it is smaller "
                  "than the minimum allowable step"
-              << std::endl;
-    return false;
-  }
-
-  return retVal == IDA_SUCCESS;
-}
-
-bool IDAInstance::idaSetStopTime() {
-  auto retVal = IDASetStopTime(idaMemory, endTime);
-
-  if (retVal == IDA_MEM_NULL) {
-    std::cerr << "IDASetMaxStep - The ida_mem pointer is NULL" << std::endl;
-    return false;
-  }
-
-  if (retVal == IDA_ILL_INPUT) {
-    std::cerr << "IDASetMaxStep - The value of tstop is not beyond the current "
-                 "t value"
               << std::endl;
     return false;
   }

--- a/lib/Solvers/IDA/Instance.cpp
+++ b/lib/Solvers/IDA/Instance.cpp
@@ -26,6 +26,14 @@ IDAInstance::IDAInstance()
     : startTime(simulation::getOptions().startTime),
       endTime(simulation::getOptions().endTime),
       timeStep(getOptions().timeStep) {
+#if SUNDIALS_VERSION_MAJOR >= 7
+#ifdef MPI_ENABLE
+  comm = MPI_COMM_WORLD;
+#else
+  comm = SUN_COMM_NULL;
+#endif
+#endif
+
   // Initially there is are no variables or equations in the instance.
   variableOffsets.push_back(0);
   equationOffsets.push_back(0);
@@ -384,8 +392,12 @@ bool IDAInstance::initialize() {
     return true;
   }
 
-#if SUNDIALS_VERSION_MAJOR >= 6
   // Create the SUNDIALS context.
+#if SUNDIALS_VERSION_MAJOR >= 7
+  if (SUNContext_Create(comm, &ctx) != 0) {
+    return false;
+  }
+#elif SUNDIALS_VERSION_MAJOR >= 6
   if (SUNContext_Create(nullptr, &ctx) != 0) {
     return false;
   }

--- a/lib/Solvers/KINSOL/Instance.cpp
+++ b/lib/Solvers/KINSOL/Instance.cpp
@@ -23,6 +23,14 @@ using namespace marco::runtime::sundials::kinsol;
 
 namespace marco::runtime::sundials::kinsol {
 KINSOLInstance::KINSOLInstance() {
+#if SUNDIALS_VERSION_MAJOR >= 7
+#ifdef MPI_ENABLE
+  comm = MPI_COMM_WORLD;
+#else
+  comm = SUN_COMM_NULL;
+#endif
+#endif
+
   // Initially there is are no variables or equations in the instance.
   variableOffsets.push_back(0);
   equationOffsets.push_back(0);
@@ -278,8 +286,12 @@ bool KINSOLInstance::initialize() {
     return true;
   }
 
-#if SUNDIALS_VERSION_MAJOR >= 6
   // Create the SUNDIALS context.
+#if SUNDIALS_VERSION_MAJOR >= 7
+  if (SUNContext_Create(comm, &ctx) != 0) {
+    return false;
+  }
+#elif SUNDIALS_VERSION_MAJOR >= 6
   if (SUNContext_Create(nullptr, &ctx) != 0) {
     return false;
   }


### PR DESCRIPTION
This PR updates the version of the SUNDIALS libraries, as well as its dependencies OpenBLAS and SuiteSparse.
It also updates the IDA setup by not specifying a stop time, to avoid the missed update of variables at the last step of fixed-step simulations, and changes the computation of the next requested time due avoid possible drift errors.